### PR TITLE
v0.1.2

### DIFF
--- a/recipe/LICENSE
+++ b/recipe/LICENSE
@@ -1,7 +1,0 @@
-Copyright 2019 Adam Gleave
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/recipe/LICENSE
+++ b/recipe/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2019 Adam Gleave
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "pytest-shard" %}
+{% set version = "0.1.2" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: b86a967fbfd1c8e50295095ccda031b7e890862ee06531d5142844f4c1d1cd67 
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+
+requirements:
+  host:
+    - pip
+    - python
+    - setuptools
+    - wheel
+  run:
+    - pytest
+    - python
+
+test:
+  imports:
+    - pytest_shard
+  requires:
+    - pip
+    - ripgrep
+  commands:
+    - pip check
+    - pytest --traceconfig | rg pytest-shard-{{ version }}
+
+about:
+  home: "https://github.com/AdamGleave/pytest-shard"
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: "Shards tests based on a hash of their test name."
+  description: |
+    Enables easy parallelism across machines, suitable for a wide variety of
+    continuous integration services. Tests are split at the finest level of
+    granularity, individual test cases, enabling parallelism even if all of your
+    tests are in a single file (or even single parameterized test method).
+  doc_url: https://github.com/AdamGleave/pytest-shard/blob/master/README.md
+  dev_url: https://github.com/AdamGleave/pytest-shard
+
+extra:
+  recipe-maintainers:
+    - danpetry

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ about:
   license: MIT
   license_family: MIT
   license_url: https://github.com/AdamGleave/pytest-shard/blob/53745ccddf016be134da4a42e94222eae8cf1564/LICENSE
-  summary: "Shards tests based on a hash of their test name."
+  summary: Shards tests based on a hash of their test name.
   description: |
     Enables easy parallelism across machines, suitable for a wide variety of
     continuous integration services. Tests are split at the finest level of

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ test:
     - pytest --traceconfig | rg pytest-shard-{{ version }}
 
 about:
-  home: "https://github.com/AdamGleave/pytest-shard"
+  home: https://github.com/AdamGleave/pytest-shard
   license: MIT
   license_family: MIT
   license_url: https://github.com/AdamGleave/pytest-shard/blob/53745ccddf016be134da4a42e94222eae8cf1564/LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ about:
     continuous integration services. Tests are split at the finest level of
     granularity, individual test cases, enabling parallelism even if all of your
     tests are in a single file (or even single parameterized test method).
-  doc_url: https://github.com/AdamGleave/pytest-shard/blob/64610a08dac6b0511b6d51cf895d0e1040d162ad/README.md
+  doc_url: https://github.com/AdamGleave/pytest-shard/blob/53745ccddf016be134da4a42e94222eae8cf1564/README.md
   dev_url: https://github.com/AdamGleave/pytest-shard
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ about:
   home: "https://github.com/AdamGleave/pytest-shard"
   license: MIT
   license_family: MIT
-  license_url: https://github.com/AdamGleave/pytest-shard/blob/64610a08dac6b0511b6d51cf895d0e1040d162ad/LICENSE
+  license_url: https://github.com/AdamGleave/pytest-shard/blob/53745ccddf016be134da4a42e94222eae8cf1564/LICENSE
   summary: "Shards tests based on a hash of their test name."
   description: |
     Enables easy parallelism across machines, suitable for a wide variety of

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,14 +37,14 @@ about:
   home: "https://github.com/AdamGleave/pytest-shard"
   license: MIT
   license_family: MIT
-  license_file: LICENSE
+  license_url: https://github.com/AdamGleave/pytest-shard/blob/64610a08dac6b0511b6d51cf895d0e1040d162ad/LICENSE
   summary: "Shards tests based on a hash of their test name."
   description: |
     Enables easy parallelism across machines, suitable for a wide variety of
     continuous integration services. Tests are split at the finest level of
     granularity, individual test cases, enabling parallelism even if all of your
     tests are in a single file (or even single parameterized test method).
-  doc_url: https://github.com/AdamGleave/pytest-shard/blob/master/README.md
+  doc_url: https://github.com/AdamGleave/pytest-shard/blob/64610a08dac6b0511b6d51cf895d0e1040d162ad/README.md
   dev_url: https://github.com/AdamGleave/pytest-shard
 
 extra:


### PR DESCRIPTION
Initial package release.
Required to support pytorch test suite updates.

[Upstream](https://github.com/AdamGleave/pytest-shard/tree/master)

Upstream didn't include the LICENSE in their pip package, and also didn't pin the release on GitHub. So I had to use license_url and use the hash of the latest commit. The code changes at this commit are four years old whereas the release is less than three, so safe to assume it's this commit that's been released.